### PR TITLE
aromatizes/cleans structures from sketcher

### DIFF
--- a/backend/app/app/api/v2/endpoints/molecule.py
+++ b/backend/app/app/api/v2/endpoints/molecule.py
@@ -37,10 +37,10 @@ def valid_smiles(smiles):
         When a smile string cannot be created from an rdkit molecule.
     """
     mol = Chem.MolFromSmiles(smiles)
-    Chem.SanitizeMol(mol)
     if mol is None:
         raise HTTPException(status_code=400, detail="Invalid Smiles")
 
+    Chem.SanitizeMol(mol)
     smiles = Chem.MolToSmiles(mol)
     if smiles is None:
         raise HTTPException(status_code=400, detail="Invalid Smiles")

--- a/backend/app/app/api/v2/endpoints/molecule.py
+++ b/backend/app/app/api/v2/endpoints/molecule.py
@@ -37,8 +37,10 @@ def valid_smiles(smiles):
         When a smile string cannot be created from an rdkit molecule.
     """
     mol = Chem.MolFromSmiles(smiles)
+    Chem.SanitizeMol(mol)
     if mol is None:
         raise HTTPException(status_code=400, detail="Invalid Smiles")
+
     smiles = Chem.MolToSmiles(mol)
     if smiles is None:
         raise HTTPException(status_code=400, detail="Invalid Smiles")
@@ -133,21 +135,12 @@ def search_molecules(
     db: Session = Depends(deps.get_db),
 ):
     # Check if the substructure provided is valid
-    valid_smiles(substructure)
+    substructure = valid_smiles(substructure)
 
-    # The original query is not doing a substructure search at all. It is doing string
-    # comparisons between the substructure and the molecule smiles string.
-    # added WHERE mol@>:substructure. Leaving order by results in a
-    # very slow query, as mentioned in this blog
+    # Very slow query observed for substructure search.
+    # set enable_sort=off as advised by this blog to improve speed.
     # https://depth-first.com/articles/2021/08/11/the-rdkit-postgres-ordered-substructure-search-problem/
-    # Adopting their solution works  (set enable_sort=off)
-    # However, this isn't the (only) problem.
-    # returning the data is very slow.
-
-    # Create mol from smiles in db - select mol_from_smiles('smiles')
-    # currently does a substructure search then orders by molecular fingerprint.
-    # Timing - without setting enable_sort = off about 34 seconds for 100 molecules
-    # with enable_sort off, 0.039 seconds
+    # ::qmol in the following query allows for SMARTS strings.
 
     sql = text(
         """

--- a/frontend/src/components/KetcherPopup.jsx
+++ b/frontend/src/components/KetcherPopup.jsx
@@ -7,6 +7,8 @@ import Dialog from '@mui/material/Dialog';
 import Slide from '@mui/material/Slide';
 
 import { Ketcher } from 'ketcher-core';
+//import { convertStructToString } from 'ketcher-core'
+import { ChemicalMimeType } from 'ketcher-core';
 import { StandaloneStructServiceProvider } from 'ketcher-standalone';
 import { Editor } from 'ketcher-react';
 import "ketcher-react/dist/index.css";
@@ -28,7 +30,9 @@ export default function FullScreenDialog({ ketcherCallBack }) {
   };
 
   async function handleClose() {
-      const smiles = await ketcher.getSmiles().then(result => {return result;});
+      let smiles = await ketcher.getSmiles().then(result => {return result;});
+      let mol = await ketcher.indigo.aromatize(smiles).then(result => {return result;});
+      smiles = await ketcher.indigo.convert(mol, {outputFormat: ChemicalMimeType.DaylightSmiles }).then(result => {return result.struct})
       const SMARTS = await ketcher.getSmarts().then(result => {return result;});
       ketcherCallBack([smiles, SMARTS]);
       setOpen(false);


### PR DESCRIPTION
This PR adds automatic cleaning and aromatization of molecules on the substructure search page.

Before this PR, drawing a benzene as shown in the image below would result in no matches being found unless you pushed the "aromatize" button. This PR adds the conversion to both the front end and the backend.

![image](https://github.com/MolSSI/kraken/assets/18010556/c2229333-3183-41fa-9cfe-2e5e60622c67)
