### PR TITLE
Fix/neighbors

### DIFF
--- a/frontend/src/pages/SearchHook.jsx
+++ b/frontend/src/pages/SearchHook.jsx
@@ -207,13 +207,13 @@ export default function SearchHook () {
         }
         <Container sx={{display: 'flex', justifyContent: 'center', my: 3}}>
             <Box sx={{ display: 'flex' }}>
-             { isLoading && <CircularProgress sx={{ color: "#ed1c24" }} /> }
+             { isLoading && <CircularProgress /> }
              { !isLoading && !validSmiles  && <Typography>Search string is not valid SMILES or SMARTS. Please provide valid SMILES or SMARTS strings.</Typography> }
              { !isLoading && validSmiles && Object.keys(svg_results).length > 0 && 
              <Container> 
                 { dynamicGrid(svg_results)  }
                 <Box sx={{ display: 'flex', justifyContent: 'center', my: 3 }}>
-                  { isLoadingMore ? <CircularProgress sx={{ color: "#ed1c24" }} /> 
+                  { isLoadingMore ? <CircularProgress /> 
                   : <ThemeProvider theme={theme}>
                       <Button disabled={updatedParameters} variant="contained" sx={{ my: 3 }} onClick={ () => loadMore() } >Load More</Button>
                     </ThemeProvider> 


### PR DESCRIPTION
This PR removes the ability to search based on UMAP and different PC components. The page now only searches on all four PCs by default. The user can still choose the dimensions on which to visualize the data in the graph.

This PR also changes the color of `CircularProgress` on the substructure search page. I think it's been changed most other places.