### PR TITLE
add queries for adding new tables and routes for molecule data download

### DIFF
--- a/add_data_tables.sql
+++ b/add_data_tables.sql
@@ -1,0 +1,68 @@
+CREATE TABLE ml_data (
+    molecule_id INTEGER,
+    property TEXT,
+    max DOUBLE PRECISION,
+    min DOUBLE PRECISION,
+    delta DOUBLE PRECISION,
+    vburminconf DOUBLE PRECISION,
+    boltzmann_average DOUBLE PRECISION
+);
+
+ALTER TABLE ml_data
+ADD CONSTRAINT fk_molecule_id
+FOREIGN KEY (molecule_id) REFERENCES molecule(molecule_id);
+
+CREATE INDEX idx_ml_data_molecule_id ON ml_data(molecule_id);
+
+\COPY ml_data FROM 'ml_data_json_table.csv' DELIMITER ',' CSV HEADER;
+
+CREATE TABLE dft_data (
+    molecule_id INTEGER,
+    property TEXT,
+    max DOUBLE PRECISION,
+    min DOUBLE PRECISION,
+    delta DOUBLE PRECISION,
+    vburminconf DOUBLE PRECISION,
+    boltzmann_average DOUBLE PRECISION
+);
+
+ALTER TABLE dft_data
+ADD CONSTRAINT fk_molecule_id
+FOREIGN KEY (molecule_id) REFERENCES molecule(molecule_id);
+
+CREATE INDEX idx_dft_data_molecule_id ON dft_data(molecule_id);
+
+\COPY dft_data FROM 'dft_data_json_table.csv' DELIMITER ',' CSV HEADER;
+
+CREATE TABLE xtb_data (
+    molecule_id INTEGER,
+    property TEXT,
+    max DOUBLE PRECISION,
+    min DOUBLE PRECISION,
+    boltzmann_average DOUBLE PRECISION
+);
+
+ALTER TABLE xtb_data
+ADD CONSTRAINT fk_molecule_id
+FOREIGN KEY (molecule_id) REFERENCES molecule(molecule_id);
+
+CREATE INDEX idx_xtb_data_molecule_id ON xtb_data(molecule_id);
+
+\COPY xtb_data FROM 'xtb_data_json_table.csv' DELIMITER ',' CSV HEADER;
+
+
+CREATE TABLE xtb_ni_data (
+    molecule_id INTEGER,
+    property TEXT,
+    boltzmann_average DOUBLE PRECISION,
+    max DOUBLE PRECISION,
+    min DOUBLE PRECISION
+);
+
+ALTER TABLE xtb_ni_data
+ADD CONSTRAINT fk_molecule_id
+FOREIGN KEY (molecule_id) REFERENCES molecule(molecule_id);
+
+CREATE INDEX idx_xtb_ni_data_molecule_id ON xtb_ni_data(molecule_id);
+
+\COPY xtb_ni_data FROM 'xtb_ni_data_json_table.csv' DELIMITER ',' CSV HEADER;

--- a/backend/environment.yaml
+++ b/backend/environment.yaml
@@ -10,6 +10,7 @@ dependencies:
   - alembic 
   - psycopg2-binary 
   - sqlalchemy 
+  - pandas
   - tenacity 
   - uvicorn 
   - curl 


### PR DESCRIPTION
this PR adds API routes for downloading data as CSV. It requires importing data for each data type (`ml`, `dft`, xtb`, `xtb_ni`) into new tables for each data type.

The added API endpoints are

- `/api/molecules/data/export/{molecule_id}`
- `/api/molecules/data/export?molecule_id=X,Y,Z` 

The first API endpoint retrieves data for a particular molecule ID. The second retrieves for multiple molecules based on ID. Both return `ml` data by default. Different data can be returned by adding a parameter `data_type=SOMETHING` where something can be `ml`, `xtb`, `xtb_ni`, or `dft`