### PR TITLE
Small UI changes and fixing Internal Server Error 500 in console log

### DIFF
--- a/docs/docs.dockerfile
+++ b/docs/docs.dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.11
 
 WORKDIR /docs/
 ADD . /docs/

--- a/frontend/src/components/MoleculeDataTable.jsx
+++ b/frontend/src/components/MoleculeDataTable.jsx
@@ -48,7 +48,7 @@ async function downloadData(molecule_id, data_type) {
 }
 
 
-function CustomFooter({ selectedDataType, setSelectedDataType, moleculeID }) {
+function CustomFooter({ selectedDataType, setSelectedDataType, moleculeID, download }) {
     const handleChange = (event) => {
       setSelectedDataType(event.target.value);
     };
@@ -66,7 +66,7 @@ function CustomFooter({ selectedDataType, setSelectedDataType, moleculeID }) {
           <MenuItem value="XTB Data">XTB Data</MenuItem>
           <MenuItem value="XTB_NI Data">XTB_NI Data</MenuItem>
         </Select>
-        <Button variant="contained" color="primary" sx={{ marginLeft: 'auto', marginRight: '16px', verticalAlign: 'middle' }} onClick={() => { downloadData(moleculeID, dataTypeMapping[selectedDataType]) }} >
+        <Button disabled={!download} variant="contained" color="primary" sx={{ marginLeft: 'auto', marginRight: '16px', verticalAlign: 'middle' }} onClick={() => { downloadData(moleculeID, dataTypeMapping[selectedDataType]) }} >
             Download CSV
         </Button>
         <GridFooter sx={{
@@ -91,6 +91,7 @@ export default function MoleculeDataTable({ molecule_id, initial_data_type }) {
     const [data_type, setDataType] = useState(initial_data_type);
     const [selectedDataType, setSelectedDataType] = useState("ML Data"); // Set the default value to "ML Data"
     const [moleculeID, setMoleculeID] = useState(molecule_id);
+    const [download, setDownload] = useState(true); // Allow CSV download
 
     useEffect(() => {
         async function fetchData() {
@@ -112,6 +113,14 @@ export default function MoleculeDataTable({ molecule_id, initial_data_type }) {
     useEffect(() => {
         async function fetchData() {
             const data = await retrieveData(moleculeID, data_type);
+
+            // Check to see if the data is empty, set download to false.
+            if (!data) {
+                setDownload(false);
+            }
+            else {
+                setDownload(true);
+            }
             setMoleculeData(data);
         }
 
@@ -144,7 +153,7 @@ export default function MoleculeDataTable({ molecule_id, initial_data_type }) {
                 columns={columns}
                 components={{Footer: CustomFooter, NoRowsOverlay: CustomNoRowsOverlay}}
                 componentsProps={{
-                    footer: { selectedDataType, setSelectedDataType, moleculeID },
+                    footer: { selectedDataType, setSelectedDataType, moleculeID, download },
                     noRowsOverlay: { selectedDataType },
                 }}
                 initialState={{

--- a/frontend/src/components/MoleculeDataTable.jsx
+++ b/frontend/src/components/MoleculeDataTable.jsx
@@ -17,10 +17,18 @@ const dataTypeMapping = {
 async function retrieveData(molecule_id, data_type="ml") {
     try {
         const response = await fetch(`/api/molecules/data/export/${molecule_id}?data_type=${data_type}&return_type=json`);
-        const data = await response.json();
-        console.log(data_type);
-        console.log(data);
-        return data;
+        
+        // If the status code is 200 we have data for the data type and we can return it, if it is 204 there is no data and we just return null
+        if (response.status === 200) {
+            const data = await response.json();
+            console.log(data_type);
+            console.log(data);
+            return data;
+        } else if (response.status === 204) {
+            console.log("There is no data for this molecule: ", molecule_id, "of type: ", data_type);
+            return null;
+        }
+        // Catches other errors
     } catch (error) {
         console.log(error);
         return null;

--- a/frontend/src/components/MoleculeDataTable.jsx
+++ b/frontend/src/components/MoleculeDataTable.jsx
@@ -54,20 +54,20 @@ function CustomFooter({ selectedDataType, setSelectedDataType, moleculeID }) {
     };
   
     return (
-      <GridFooterContainer>
+      <GridFooterContainer sx= {{ overflowX: 'auto', whiteSpace: 'nowrap' }}>
         <Select
           value={selectedDataType}
           onChange={handleChange}
           displayEmpty
-          sx={{ marginLeft: '8px', marginRight: '16px', display: 'inline-block', verticalAlign: 'middle' }}
+          sx={{ marginLeft: '8px', marginRight: '16px', height: '40px', verticalAlign: 'middle' }}
         >
           <MenuItem value="ML Data">ML Data</MenuItem>
           <MenuItem value="DFT Data">DFT Data</MenuItem>
           <MenuItem value="XTB Data">XTB Data</MenuItem>
           <MenuItem value="XTB_NI Data">XTB_NI Data</MenuItem>
         </Select>
-        <Button variant="contained" color="primary" sx={{ marginLeft: 'auto', marginRight: '16px', display: 'inline-block', verticalAlign: 'middle' }} onClick={() => { downloadData(moleculeID, dataTypeMapping[selectedDataType]) }} >
-            Download as CSV
+        <Button variant="contained" color="primary" sx={{ marginLeft: 'auto', marginRight: '16px', verticalAlign: 'middle' }} onClick={() => { downloadData(moleculeID, dataTypeMapping[selectedDataType]) }} >
+            Download CSV
         </Button>
         <GridFooter sx={{
           border: 'none', // To delete double border.

--- a/frontend/src/pages/Molecule.jsx
+++ b/frontend/src/pages/Molecule.jsx
@@ -2,7 +2,6 @@ import Graph from "../components/Graph"
 import React, { useEffect, useState } from 'react';
 import { useParams } from "react-router-dom";
 import { Box, Grid, Container, TextField, MenuItem, Card, CardContent, Select, InputLabel, FormControl, ThemeProvider} from "@mui/material";
-import Button from "@mui/material/Button";
 import Typography from '@mui/material/Typography';
 import { CircularProgress } from "@mui/material";
 import { retrieveSVG } from "../common/MoleculeUtils";


### PR DESCRIPTION
In this PR, I have made small changes to the UI for the data table:
1. Changing data type selection size
2. Making the button for downloading csvs slightly more responsive (it still has small issues when the screen width is <600px, but this can be circumvented further by putting an icon representing download and just the words csv as it would save a ton of space)
3. Blocking the csv download if there is no data. Currently you could download an empty csv so I have removed the ability to do so.

I also made a small change in the backend to return a response code 204 if there is no data for the specific data_type requested. Currently, if there is no data for a specific data_type, we run into a 500 error even though technically the response is correct and expected. This change  is so that we can tell data related issues apart from other errors. I also changed the appropriate code in the frontend fetch request.

I have left console.log statements in for now for debugging, but they will be removed before merging. I also had to change the docker file for docs to specify python 3.11 because python 3.12 had issues building uvloop. (This will probably be reverted before merging when uvloop fixes its issues)

One thing I was thinking about from a UI/UX perspective is what if we were to fetch all the data_types for a molecule on load up but then only populate the data_type selection with the ones with data. This would cause more overhead on page load but would eliminate the need for block out the CSV button and would not show the  "data_type Data is not available for this molecule". Although it may lead to confusion as to why some molecules has some data types and not others. Wondering what you think about this.

![small_changes_UI](https://github.com/MolSSI/kraken/assets/69454662/49deeb20-223a-4bcc-9d65-9ee09e64d7b7)