### PR TITLE
Change format of molecule table 

### DIFF
--- a/backend/app/app/schemas/__init__.py
+++ b/backend/app/app/schemas/__init__.py
@@ -1,3 +1,3 @@
 from .conformer import Conformer, Atom
-from .molecule import Molecule, MoleculeSimple, MoleculeComponents, MoleculeNeighbors, MoleculeIdentifiers
+from .molecule import Molecule, MoleculeSimple, MoleculeComponents, MoleculeNeighbors, MoleculeIdentifiers, MoleculeData
 from .property_list import PropertyList

--- a/backend/app/app/schemas/molecule.py
+++ b/backend/app/app/schemas/molecule.py
@@ -13,6 +13,14 @@ class Molecule(BaseModel):
     xtb_ni_data: Optional[Dict] = None
     ml_data: Optional[Dict] = None
 
+class MoleculeData(BaseModel):
+    property: str
+    max: Optional[float] = None
+    min: Optional[float] = None
+    delta: Optional[float] = None
+    boltzmann_average: Optional[float] = None
+    vburminconf: Optional[float] = None
+
 class MoleculeSimple(BaseModel):
     molecule_id: int
     umap1: Optional[float] = None

--- a/frontend/src/components/MoleculeDataTable.jsx
+++ b/frontend/src/components/MoleculeDataTable.jsx
@@ -10,14 +10,14 @@ import DownloadIcon from '@mui/icons-material/Download';
 const dataTypeMapping = {
     "ML Data": "ml",
     "DFT Data": "dft",
-    "XTB Data": "xtb",
-    "XTB_NI Data": "xtb_ni"
+    "xTB Data": "xtb",
+    "xTB_Ni Data": "xtb_ni"
 };
 
 
 async function retrieveData(molecule_id, data_type="ml") {
     try {
-        const response = await fetch(`/api/molecules/data/export/${molecule_id}?data_type=${data_type}&return_type=json`);
+        const response = await fetch(`/api/molecules/data/export/${molecule_id}?data_type=${data_type}`);
         
         // If the status code is 200 we have data for the data type and we can return it, if it is 204 there is no data and we just return null
         if (response.status === 200) {
@@ -35,7 +35,7 @@ async function retrieveData(molecule_id, data_type="ml") {
 
 async function downloadData(molecule_id, data_type) {
     try {
-        const response = await fetch(`/api/molecules/data/export/${molecule_id}?data_type=${data_type}&return_type=csv`);
+        const response = await fetch(`/api/molecules/data/export/${molecule_id}?data_type=${data_type}`);
         
         if(response.status === 200) {
             const blob = await response.blob();
@@ -69,8 +69,8 @@ function CustomFooter({ selectedDataType, setSelectedDataType, moleculeID, downl
         >
           <MenuItem value="ML Data">ML Data</MenuItem>
           <MenuItem value="DFT Data">DFT Data</MenuItem>
-          <MenuItem value="XTB Data">XTB Data</MenuItem>
-          <MenuItem value="XTB_NI Data">XTB_NI Data</MenuItem>
+          <MenuItem value="xTB Data">xTB Data</MenuItem>
+          <MenuItem value="xTB_Ni Data">xTB_Ni Data</MenuItem>
         </Select>
         <Button disabled={!download} variant="contained" color="primary" sx={{ marginLeft: 'auto', marginRight: '16px', verticalAlign: 'middle' }} onClick={() => { downloadData(moleculeID, dataTypeMapping[selectedDataType]) }} >
         <DownloadIcon /> CSV
@@ -140,22 +140,35 @@ export default function MoleculeDataTable({ molecule_id, initial_data_type }) {
 
     const columns = [
         { field: 'property', headerName: 'Property', filterable: true, flex: true },
-        { field: 'value', headerName: 'Value', width: 150, filterable: true, headerAlign: 'right', align: 'right', flex: true }
+        { field: 'min', headerName: 'Min', filterable: true, headerAlign: 'right', align: 'right', flex: true },
+        { field: 'max', headerName: 'Max', filterable: true, headerAlign: 'right', align: 'right', flex: true },
+        { field: 'delta', headerName: 'Delta', filterable: true, headerAlign: 'right', align: 'right', flex: true },
+        { field: 'vburminconf', headerName: 'vbur min conf', filterable: true, headerAlign: 'right', align: 'right', flex: true },
+        { field: 'boltzmann_average', headerName: 'Boltz', filterable: true, headerAlign: 'right', align: 'right', flex: true },
     ];
+    
+    // Filter out delta and vburminconf columns for xTB data.
+    let displayColumns = columns;
+    if (selectedDataType === "xTB Data" || selectedDataType === "xTB_Ni Data") {
+        displayColumns = columns.filter(column => column.field !== 'delta' && column.field !== 'vburminconf');
+    }
 
-    const rows = moleculeData ? Object.keys(moleculeData)
-        .filter(key => key !== 'smiles' && key !== 'molecule_id')
-        .map(key => ({
-            id: key,
-            property: key,
-            value: moleculeData[key],
+    const rows = moleculeData ? moleculeData
+        .map(item => ({
+            id: item.property,
+            property: item.property,
+            max: item.max,
+            min: item.min,
+            delta: item.delta,
+            boltzmann_average: item.boltzmann_average,
+            vburminconf: item.vburminconf,
         })) : [];
 
     return (
         <Paper elevation={3} style={{ height: 400, width: '100%' }}>
             <DataGrid
                 rows={rows}
-                columns={columns}
+                columns={displayColumns}
                 components={{Footer: CustomFooter, NoRowsOverlay: CustomNoRowsOverlay}}
                 componentsProps={{
                     footer: { selectedDataType, setSelectedDataType, moleculeID, download },

--- a/frontend/src/components/MoleculeDataTable.jsx
+++ b/frontend/src/components/MoleculeDataTable.jsx
@@ -6,6 +6,8 @@ import { Select, MenuItem } from '@mui/material';
 import Button from '@mui/material/Button';
 import DownloadIcon from '@mui/icons-material/Download';
 
+import ResponsiveButton from './ResponsiveButton'; 
+
 
 const dataTypeMapping = {
     "ML Data": "ml",
@@ -17,7 +19,7 @@ const dataTypeMapping = {
 
 async function retrieveData(molecule_id, data_type="ml") {
     try {
-        const response = await fetch(`/api/molecules/data/export/${molecule_id}?data_type=${data_type}`);
+        const response = await fetch(`/api/molecules/data/${molecule_id}?data_type=${data_type}`);
         
         // If the status code is 200 we have data for the data type and we can return it, if it is 204 there is no data and we just return null
         if (response.status === 200) {
@@ -72,9 +74,13 @@ function CustomFooter({ selectedDataType, setSelectedDataType, moleculeID, downl
           <MenuItem value="xTB Data">xTB Data</MenuItem>
           <MenuItem value="xTB_Ni Data">xTB_Ni Data</MenuItem>
         </Select>
-        <Button disabled={!download} variant="contained" color="primary" sx={{ marginLeft: 'auto', marginRight: '16px', verticalAlign: 'middle' }} onClick={() => { downloadData(moleculeID, dataTypeMapping[selectedDataType]) }} >
-        <DownloadIcon /> CSV
-        </Button>
+        <ResponsiveButton expandedButtonContent={"Download CSV"}  
+                            collapsedButtonContent={<span><DownloadIcon /> CSV</span>}
+                            disabled={!download} 
+                            variant="contained" 
+                            color="primary"
+                             sx={{ marginLeft: 'auto', marginRight: '16px', verticalAlign: 'middle' }} 
+                             onClick={() => { downloadData(moleculeID, dataTypeMapping[selectedDataType]) }} />
         <GridFooter sx={{
           border: 'none', // To delete double border.
         }} />
@@ -119,9 +125,8 @@ export default function MoleculeDataTable({ molecule_id, initial_data_type }) {
     useEffect(() => {
         async function fetchData() {
             const data = await retrieveData(moleculeID, data_type);
-
             // Check to see if the data is empty, set download to false.
-            if (!data) {
+            if (data.length==0) {
                 setDownload(false);
             }
             else {

--- a/frontend/src/components/ResponsiveButton.jsx
+++ b/frontend/src/components/ResponsiveButton.jsx
@@ -1,0 +1,28 @@
+import React, { useState, useEffect } from 'react';
+import Button from '@mui/material/Button';
+
+function ResponsiveButton({expandedButtonContent, collapsedButtonContent, ...props}) {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWidth(window.innerWidth);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return (
+        <Button
+          {...props}  
+        >
+          {width > 768 ? expandedButtonContent : collapsedButtonContent}
+        </Button>
+      );
+}
+
+export default ResponsiveButton;

--- a/frontend/src/pages/Molecule.jsx
+++ b/frontend/src/pages/Molecule.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from "react-router-dom";
 import { Box, Grid, Container, TextField, MenuItem, Card, CardContent, Select, InputLabel, FormControl, ThemeProvider} from "@mui/material";
 import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
 import { CircularProgress } from "@mui/material";
 import { retrieveSVG } from "../common/MoleculeUtils";
 import { NGLStage, Component } from "../components/NGL"


### PR DESCRIPTION
This PR makes requested changes to the data table on the molecule page. CCAS requested that the table have the headers "property", "min", "max", "delta"...etc. This is how the data is kept in the database.

To facilitate showing this, an API route for data retrieval as json (`molecule/data/{molecule_id}?data_type={data-source}` was added and returns results from the database without changing the formatting.

The `json` option was removed from the `export` route.

![image](https://github.com/MolSSI/kraken/assets/18010556/d4c84a32-ea14-4048-b64a-2db36de351ea)

I also added a new component, `ResponsiveButton` for use in the molecule data table. On large screens, the button will read "Download CSV', while on smaller screens a download icon will be shown (see below for small screen button)

![image](https://github.com/MolSSI/kraken/assets/18010556/098904de-2c71-41fd-9fa3-e8c572ede338)

