### PR TITLE
adjust frontend based on requests from CCAS

### DIFF
--- a/frontend/src/common/MoleculeUtils.jsx
+++ b/frontend/src/common/MoleculeUtils.jsx
@@ -20,7 +20,7 @@ async function substructureSearch(substructure, limit=48, skip=0, signal) {
     const response =  await fetch(`/api/molecules/search/?substructure=${encoded}&skip=${skip}&limit=${limit}`, {signal: signal})
 
     if (!response.ok) {
-        throw new Error('invalid smiles')
+        throw new Error('Invalid SMILES')
     }
 
     else {
@@ -71,14 +71,14 @@ function dynamicGrid( svgs ) {
             // True condition - render Item with border if distance is 0.
             <Item sx={{border: 3, borderColor: '#ed1c24'}}>
             <img alt='' src={`data:image/svg+xml;utf8,${encodeURIComponent(result.svg)}`} />
-            <Typography sx={{ wordBreak: "break-word" }}> <strong>Smiles: </strong> { result.smiles }</Typography>
+            <Typography sx={{ wordBreak: "break-word" }}> <strong>SMILES: </strong> { result.smiles }</Typography>
             <Button variant="contained" sx={{ m: 0.5 }} onClick={() => moleculePage(result.molecule_id)}>View Details</Button>
             </Item>
             // False condition - render Item without border if distance is not 0.
             :
             <Item>
             <img alt='' src={`data:image/svg+xml;utf8,${encodeURIComponent(result.svg)}`} />
-            <Typography sx={{ wordBreak: "break-word" }}> <strong>Smiles: </strong> { result.smiles }</Typography>
+            <Typography sx={{ wordBreak: "break-word" }}> <strong>SMILES: </strong> { result.smiles }</Typography>
             
             {result.distance !== undefined && (
                 <Typography sx={{ wordBreak: "break-word" }}>

--- a/frontend/src/components/DFTTable.jsx
+++ b/frontend/src/components/DFTTable.jsx
@@ -37,7 +37,7 @@ function DataTable() {
                         <TableRow>
                             <TableCell>Condensed Properties</TableCell>
                             <TableCell>Description</TableCell>
-                            <TableCell>For XTB</TableCell>
+                            <TableCell>For xTB</TableCell>
                             <TableCell>For DFT</TableCell>
                             <TableCell>For ML</TableCell>
                         </TableRow>

--- a/frontend/src/components/DFTTable.jsx
+++ b/frontend/src/components/DFTTable.jsx
@@ -13,18 +13,19 @@ function createData(
     name,
     description,
     forXTB,
-    forDFT
+    forDFT,
+    forML,
 ) {
-    return { name, description, forXTB, forDFT }
+    return { name, description, forXTB, forDFT, forML }
 };
 
 const rows = [
-    createData("boltz", "Boltzmann-weighted average of all conformers' properties (T=298.15 K)", true, true),
-    createData("max", "highest value of a property of any conformer", true, true),
-    createData("min", "lowest value of a property of any conformer", true, true),
-    createData("std", "standard deviation of the value across all conformers", true, false),
-    createData("vburminconf", "property value of the conformer with the smallest buried volume", false, true),
-    createData("delta", "difference between the maximum and minimum property values", false, true),
+    createData("boltz", "Boltzmann-weighted average of all conformers' properties (T=298.15 K)", true, true, true),
+    createData("max", "highest value of a property of any conformer", true, true, true),
+    createData("min", "lowest value of a property of any conformer", true, true,true),
+    createData("std", "standard deviation of the value across all conformers", true, false, false),
+    createData("vburminconf", "property value of the conformer with the smallest buried volume", false, true, true),
+    createData("delta", "difference between the maximum and minimum property values", false, true, true),
 ];
 
 function DataTable() {
@@ -38,6 +39,7 @@ function DataTable() {
                             <TableCell>Description</TableCell>
                             <TableCell>For XTB</TableCell>
                             <TableCell>For DFT</TableCell>
+                            <TableCell>For ML</TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>
@@ -47,6 +49,7 @@ function DataTable() {
                                 <TableCell>{row.description}</TableCell>
                                 <TableCell>{row.forXTB ? '✔️' : ''}</TableCell>
                                 <TableCell>{row.forDFT ? '✔️' : ''}</TableCell>
+                                <TableCell>{row.forML ? '✔️' : ''}</TableCell>
                             </TableRow>
                         ))}
                     </TableBody>

--- a/frontend/src/components/Graph.jsx
+++ b/frontend/src/components/Graph.jsx
@@ -209,33 +209,36 @@ export default function Graph({ molData, componentArray, type, neighborSearch, c
     return (
         <Container sx={containerStyle ? containerStyle : {}}>
             <Container sx={{display: 'flex', flexDirection: "row", justifyContent: 'center'}}>
-            <TextField
-                id="dimension-outline"
+            {type === 'pca' ? (
+            <>
+                <TextField
+                id="dimension-outline-x"
                 value={xIndex}
                 label="x-axis"
                 select
                 style={{width: 250}}
                 sx={{ m: 0.5 }}
                 onChange={ function(event) {setXIndex(parseInt(event.target.value));}}
-            >
+                >
                 {componentArray.map((item, index) => (
                     <MenuItem key={index} value={index}>{axis_dict[type + item]}</MenuItem>
                 ))}
-
-            </TextField>
-            <TextField
-                id="dimension-outline"
+                </TextField>
+                <TextField
+                id="dimension-outline-y"
                 value={yIndex}
                 label="y-axis"
                 select
                 style={{width: 250}}
                 sx={{ m: 0.5 }}
                 onChange={ function(event) {setYIndex(parseInt(event.target.value));}}
-            >
+                >
                 {componentArray.map((item, index) => (
                     <MenuItem key={index} value={index}>{axis_dict[type + item]}</MenuItem>
                 ))}
-            </TextField>
+                </TextField>
+            </>
+            ) : null}
       </Container>
             {myPlot}
       </Container>);

--- a/frontend/src/components/MoleculeDataTable.jsx
+++ b/frontend/src/components/MoleculeDataTable.jsx
@@ -182,7 +182,7 @@ export default function MoleculeDataTable({ molecule_id, initial_data_type }) {
                 initialState={{
                     pagination: {
                         paginationModel: {
-                            pageSize: 25, // This sets the initial page size
+                            pageSize: 100, // This sets the initial page size
                         },
                     },
                 }}

--- a/frontend/src/pages/Library_Details.jsx
+++ b/frontend/src/pages/Library_Details.jsx
@@ -68,7 +68,7 @@ function Library_Details() {
         </Typography>
 
         <Typography variant="body1" paragraph>
-            Gensch, T.; dos Passos Gomes, G.; Friederich, P.; Peters, E.; Gaudin, T.; Pollice, R.; Jorner, K.; Nigam, A.; Lindner-D’Addario, M.; Sigman, M. S.; Aspuru-Guzik, A.  A Comprehensive Discovery Platform for Organophosphorus Ligands for Catalysis. J. Am. Chem. Soc. 2022, 144, 3, 1205–1217. DOI: 10.1021/jacs.1c09718
+            Gensch, T.; dos Passos Gomes, G.; Friederich, P.; Peters, E.; Gaudin, T.; Pollice, R.; Jorner, K.; Nigam, A.; Lindner-D’Addario, M.; Sigman, M. S.; Aspuru-Guzik, A.  A Comprehensive Discovery Platform for Organophosphorus Ligands for Catalysis. <span style={{ fontStyle: 'italic' }}>J. Am. Chem. Soc.</span> <span style={{ fontWeight: 'bold' }}>2022</span>, <span style={{ fontStyle: 'italic' }}>144</span>, 3, 1205–1217. DOI: 10.1021/jacs.1c09718
         </Typography>
 
     </Container>

--- a/frontend/src/pages/Molecule.jsx
+++ b/frontend/src/pages/Molecule.jsx
@@ -79,8 +79,8 @@ export default function MoleculeInfo() {
    const [ pcaNeighborData, setPcaNeighborData ] = useState([]);
    const [ identifierData, setIdentifierData ] = useState([]);
    const [ neighborData, setNeighborData ] = useState([]);
-   const [ components, setComponents ] = useState(["1", "2"]);
-   const [ type, setType ] = useState("umap");
+   const [ components, setComponents ] = useState(["1", "2", "3", "4"]);
+   const [ type, setType ] = useState("pca");
    const [ svg, setSvg ] = useState({});
    const [ allConformers, setAllConformers ] = useState([]);
    const [ conformer, setConformer ] = useState("");
@@ -138,7 +138,7 @@ export default function MoleculeInfo() {
             setSvg(items[3]);
             setIdentifierData(items[4][0]);
             // Initial set neighbor data to umap so it appears on load.
-            setNeighborData(items[1]);
+            setNeighborData(items[2]);
             // If we have conformers, we can set our states.
             if (items[0].conformers_id.length > 0)
             {
@@ -182,7 +182,8 @@ export default function MoleculeInfo() {
                   {Object.keys(molData).length > 0 && 
                         <Card>
                            <CardContent>
-                           <Typography align='left'> <strong>Smiles:</strong> {molData.smiles} </Typography>
+                           <Typography align='left'> <strong>SMILES:</strong> {molData.smiles} </Typography>
+                           <Typography align='left'> <strong>kraken Ligand ID:</strong> {molData.molecule_id} </Typography>
                            <Typography align='left'> <strong>InChI:</strong> {identifierData.InChI} </Typography>
                            <Typography align='left'> <strong>InChIKey:</strong> {identifierData.InChIKey} </Typography>
                            <Typography align='left'> <strong>Molecular Weight:</strong> {molData.molecular_weight.toFixed(2)} </Typography>
@@ -198,7 +199,7 @@ export default function MoleculeInfo() {
             {(width > 768) && allConformers.length > 0 && conformer.length > 0 && <Grid item xs={(width > 1366) ? 6 : 12}>
                <Container>
                   <FormControl fullWidth variant="standard">
-                     <InputLabel id="conformer">Conformer</InputLabel>
+                     <InputLabel id="conformer">{allConformers.length} Conformers</InputLabel>
                      <Select
                      labelId="conformer"
                      id="dimension-outline"
@@ -208,7 +209,7 @@ export default function MoleculeInfo() {
                      onChange={ function(event) {setConformer(event.target.value.toString());} }
                      >
                         {allConformers.map((item, index) => (
-                           <MenuItem key={index} value={item}>{item}</MenuItem>
+                           <MenuItem key={index} value={item}>{index+1}</MenuItem>
                         ))}
                      </Select>
                   </FormControl>


### PR DESCRIPTION
The following adjustments are made:
* captitalization for data types (xTB, xTB_Ni, etc)
* show ligand ID on molecule details page
* Smiles -> SMILES throughout site
* no dropdown for UMAP
* default chemical space changed to pca
* show number of conformers
* show conformer IDs starting at 1 (just change display for frontend)
* citation format