### PR TITLE
Adds batch download for molecules

### DIFF
--- a/frontend/src/common/MoleculeUtils.jsx
+++ b/frontend/src/common/MoleculeUtils.jsx
@@ -140,8 +140,29 @@ async function retrieveSVG(smiles, molecule_id, substructure = undefined, distan
       return retrieveSVG(item.smiles, item.molecule_id, substructure, item.dist);
     }));
   }
+
+
+const downloadMoleculeData = (moleculeIDs, context=null) => {
+  const a = document.createElement('a');
+  let search_string = `/api/molecules/data/export/batch?molecule_ids=${moleculeIDs}`;
+
+  if (context) {
+    search_string += `&context=${context}`;
+  }
+
+  a.href = search_string;
+  a.download = true; 
+  a.style.display = 'none';
+
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
   
+const extractIdsFromResults = (svg_results) => {
+  return svg_results.map(result => result.molecule_id).join(',');
+}
   
 
 
-export { retrieveSVG, retrieveAllSVGs, dynamicGrid, substructureSearch, neighborPage };
+export { retrieveSVG, retrieveAllSVGs, dynamicGrid, substructureSearch, neighborPage, downloadMoleculeData, extractIdsFromResults };

--- a/frontend/src/components/MoleculeDataTable.jsx
+++ b/frontend/src/components/MoleculeDataTable.jsx
@@ -44,7 +44,7 @@ async function downloadData(molecule_id, data_type) {
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
-            a.download = `data_${molecule_id}_${data_type}.csv`;  // you can name the file however you'd like
+            a.download = `data_${molecule_id}_${data_type}.csv`; 
             a.click();
             window.URL.revokeObjectURL(url);
         } else {

--- a/frontend/src/pages/SearchHook.jsx
+++ b/frontend/src/pages/SearchHook.jsx
@@ -12,6 +12,23 @@ import FullScreenDialog from '../components/KetcherPopup';
 
 import { substructureSearch, retrieveAllSVGs, dynamicGrid } from '../common/MoleculeUtils';
 
+const extractIdsFromResults = (svg_results) => {
+  return svg_results.map(result => result.molecule_id).join(',');
+}
+
+
+const downloadMoleculeData = (moleculeIDs) => {
+  const a = document.createElement('a');
+  a.href = `/api/molecules/data/export/batch?molecule_ids=${moleculeIDs}`;
+  a.download = true; 
+  a.style.display = 'none';
+
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+
 export default function SearchHook () {
 
     const interval = 15;
@@ -32,7 +49,13 @@ export default function SearchHook () {
     const [ switchCheck, setSwitchCheck ] = useState(true);
     const [ fromKetcher, setFromKetcher ] = useState(false);
     const [ updatedParameters, setUpdatedParameters ] = useState(false);
+    const [ moleculeIDs, setMoleculeIDs ] = useState("");
 
+    // Extract the molecule ids from the results
+    useEffect(() => {
+      setMoleculeIDs(extractIdsFromResults(svg_results));
+    }, [svg_results]);
+  
 
     // Call back function to get the smiles and SMARTS from ketcher
     const ketcherCallBack = (newState) => {
@@ -217,6 +240,7 @@ export default function SearchHook () {
                       <Button disabled={updatedParameters} variant="contained" sx={{ my: 3 }} onClick={ () => loadMore() } >Load More</Button>
 
                   }
+                  <Button variant="contained" sx={{ my: 3 }} onClick={() => downloadMoleculeData(moleculeIDs)}>Download Molecule Data</Button>
                 </Box>
                </Container>  }
             { !isLoading && validSmiles && Object.keys(svg_results).length==0 && <Typography>No results found for SMILES string.</Typography> } 

--- a/frontend/src/pages/SearchHook.jsx
+++ b/frontend/src/pages/SearchHook.jsx
@@ -10,24 +10,7 @@ import Button from '@mui/material/Button';
 
 import FullScreenDialog from '../components/KetcherPopup';
 
-import { substructureSearch, retrieveAllSVGs, dynamicGrid } from '../common/MoleculeUtils';
-
-const extractIdsFromResults = (svg_results) => {
-  return svg_results.map(result => result.molecule_id).join(',');
-}
-
-
-const downloadMoleculeData = (moleculeIDs) => {
-  const a = document.createElement('a');
-  a.href = `/api/molecules/data/export/batch?molecule_ids=${moleculeIDs}`;
-  a.download = true; 
-  a.style.display = 'none';
-
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-}
-
+import { substructureSearch, retrieveAllSVGs, dynamicGrid, extractIdsFromResults, downloadMoleculeData } from '../common/MoleculeUtils';
 
 export default function SearchHook () {
 
@@ -212,8 +195,9 @@ export default function SearchHook () {
                     Search
                     </Button>}}
                     />
+            
         </Box>
-        
+
         { toggleRepresentation &&
         <Grid component="label" container alignItems="center" spacing={1} sx={{position: 'flex', flexDirection: 'row', justifyContent: 'center', alignItems:'center'}}>
             <Grid item>SMARTS</Grid>
@@ -227,20 +211,33 @@ export default function SearchHook () {
             <Grid item>SMILES</Grid>
         </Grid>
         }
+      <Box sx={{ display: 'flex', justifyContent: 'center', my: 3 }}>
+                  { isLoadingMore ? <CircularProgress /> 
+                  : 
+                    <>
+                      <Button disabled={updatedParameters} variant="contained" sx={{ my: 3 }} onClick={ () => loadMore() } >Load More</Button>
+                      <Button variant="contained" sx={{ my: 3, ml: 2 }} onClick={() => downloadMoleculeData(moleculeIDs)}>Download Search Results</Button>
+                    </>
+                  }          
+      </Box>
         <Container sx={{display: 'flex', justifyContent: 'center', my: 3}}>
             <Box sx={{ display: 'flex' }}>
              { isLoading && <CircularProgress /> }
              { !isLoading && !validSmiles  && <Typography>Search string is not valid SMILES or SMARTS. Please provide valid SMILES or SMARTS strings.</Typography> }
              { !isLoading && validSmiles && Object.keys(svg_results).length > 0 && 
-             <Container> 
+             <Container>
+              <Container sx={{display: 'flex', justifyContent: 'left', my: 3}}>    
+                  <Typography  sx={{ fontStyle: 'italic' }}>Showing {interval + interval * (searchPage-1)} results.</Typography>
+              </Container> 
                 { dynamicGrid(svg_results)  }
                 <Box sx={{ display: 'flex', justifyContent: 'center', my: 3 }}>
                   { isLoadingMore ? <CircularProgress /> 
                   : 
+                    <>
                       <Button disabled={updatedParameters} variant="contained" sx={{ my: 3 }} onClick={ () => loadMore() } >Load More</Button>
-
-                  }
-                  <Button variant="contained" sx={{ my: 3 }} onClick={() => downloadMoleculeData(moleculeIDs)}>Download Molecule Data</Button>
+                      <Button variant="contained" sx={{ my: 3, ml: 2 }} onClick={() => downloadMoleculeData(moleculeIDs)}>Download Search Results</Button>
+                    </>
+                  }          
                 </Box>
                </Container>  }
             { !isLoading && validSmiles && Object.keys(svg_results).length==0 && <Typography>No results found for SMILES string.</Typography> } 


### PR DESCRIPTION
This PR adds the ability to download data for several molecules at once based on molecule ID.

This API endpoint was on the backend previously, but the overlap of endpoint was causing some problems

A button is added on the search pages to allow downloading from this endpoint. The file will contain molecules that are currently displayed on the search page.

![image](https://github.com/MolSSI/kraken/assets/18010556/9b656ec9-af48-4ad7-9161-3b52af164ecd)
