### PR TITLE
update for moving std to own column

### DIFF
--- a/backend/app/app/schemas/molecule.py
+++ b/backend/app/app/schemas/molecule.py
@@ -19,6 +19,7 @@ class MoleculeData(BaseModel):
     min: Optional[float] = None
     delta: Optional[float] = None
     boltzmann_average: Optional[float] = None
+    std: Optional[float] = None
     vburminconf: Optional[float] = None
 
 class MoleculeSimple(BaseModel):

--- a/frontend/src/components/MoleculeDataTable.jsx
+++ b/frontend/src/components/MoleculeDataTable.jsx
@@ -150,12 +150,17 @@ export default function MoleculeDataTable({ molecule_id, initial_data_type }) {
         { field: 'delta', headerName: 'Delta', filterable: true, headerAlign: 'right', align: 'right', flex: true },
         { field: 'vburminconf', headerName: 'vbur min conf', filterable: true, headerAlign: 'right', align: 'right', flex: true },
         { field: 'boltzmann_average', headerName: 'Boltz', filterable: true, headerAlign: 'right', align: 'right', flex: true },
+        { field: 'std', headerName: 'std', filterable: true, headerAlign: 'right', align: 'right', flex: true}
     ];
     
     // Filter out delta and vburminconf columns for xTB data.
     let displayColumns = columns;
     if (selectedDataType === "xTB Data" || selectedDataType === "xTB_Ni Data") {
         displayColumns = columns.filter(column => column.field !== 'delta' && column.field !== 'vburminconf');
+    }
+
+    else {
+        displayColumns = columns.filter(column => column.field !== 'std');
     }
 
     const rows = moleculeData ? moleculeData
@@ -167,6 +172,7 @@ export default function MoleculeDataTable({ molecule_id, initial_data_type }) {
             delta: item.delta,
             boltzmann_average: item.boltzmann_average,
             vburminconf: item.vburminconf,
+            std: item.std,
         })) : [];
 
     return (

--- a/move_std.sql
+++ b/move_std.sql
@@ -1,0 +1,34 @@
+ALTER TABLE xtb_data
+ADD COLUMN std DOUBLE PRECISION;
+
+UPDATE xtb_data
+SET std = x.boltzmann_average
+FROM (
+    SELECT 
+        SUBSTRING(property FROM 1 FOR POSITION('_std' IN property) - 1) AS property_name, 
+        boltzmann_average
+    FROM xtb_data
+    WHERE property LIKE '%_std%'
+) AS x
+WHERE xtb_data.property = x.property_name;
+
+DELETE FROM xtb_data
+WHERE property LIKE '%_std%';
+
+---------------------------------------------
+ALTER TABLE xtb_ni_data
+ADD COLUMN std DOUBLE PRECISION;
+
+UPDATE xtb_ni_data
+SET std = x.boltzmann_average
+FROM (
+    SELECT 
+        SUBSTRING(property FROM 1 FOR POSITION('_std' IN property) - 1) AS property_name, 
+        boltzmann_average
+    FROM xtb_ni_data
+    WHERE property LIKE '%_std%'
+) AS x
+WHERE xtb_ni_data.property = x.property_name;
+
+DELETE FROM xtb_ni_data
+WHERE property LIKE '%_std%';


### PR DESCRIPTION
Currently, standard deviation values in the `xtb` and `xtb_ni` tables for std are stored as things like `B1_std`. This PR introduces a script for having `std` be its own column associated with the correct property.

Necessary changes are made to the backend and frontend as well.